### PR TITLE
Allow doctrine/annotations 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "8.1.*|8.2.*|8.3.*|8.4.*",
-        "doctrine/annotations": "^1.11",
+        "doctrine/annotations": "^1.14 || ^2.0",
         "spiral/attributes": "^2.8|^3.0"
     },
     "require-dev": {

--- a/src/Annotations/ApiArrayShape.php
+++ b/src/Annotations/ApiArrayShape.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"CLASS", "METHOD", "PROPERTY"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/ApiExpectedValues.php
+++ b/src/Annotations/ApiExpectedValues.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"PROPERTY"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/ApiIgnore.php
+++ b/src/Annotations/ApiIgnore.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"CLASS", "METHOD"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/ApiIgnoreMethod.php
+++ b/src/Annotations/ApiIgnoreMethod.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"CLASS"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/ApiMapRequestToObject.php
+++ b/src/Annotations/ApiMapRequestToObject.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"METHOD"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/ApiValueExample.php
+++ b/src/Annotations/ApiValueExample.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"PROPERTY", "METHOD"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/Sometimes.php
+++ b/src/Annotations/Sometimes.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"PROPERTY"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/TimeZone.php
+++ b/src/Annotations/TimeZone.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"PROPERTY"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 #[NamedArgumentConstructor]

--- a/src/Annotations/ValidationRule.php
+++ b/src/Annotations/ValidationRule.php
@@ -11,6 +11,7 @@ use Tochka\JsonRpc\Contracts\ApiAnnotationInterface;
  * @Annotation
  * @Target({"CLASS", "METHOD", "PROPERTY"})
  * @NamedArgumentConstructor
+ * @psalm-suppress DeprecatedClass
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 #[NamedArgumentConstructor]


### PR DESCRIPTION
## Summary
- Allow doctrine/annotations 2.x while keeping 1.14 compatibility.
- This lets consumers resolve doctrine/lexer 3.x through doctrine/annotations 2.x.
- Suppress Psalm's DeprecatedClass warning for Spiral's NamedArgumentConstructor marker, which is still required for named PHP attribute arguments at runtime.

## Verification
- composer validate --strict --no-check-lock
- Composer/runtime smoke: doctrine/annotations 2.0.2 + doctrine/lexer 3.0.1
- Composer/runtime smoke: doctrine/annotations 1.14.4 + doctrine/lexer 2.1.1
- Composer/runtime smoke: doctrine/annotations 1.14.4 + doctrine/lexer 1.2.3
- composer lint
- composer analyze